### PR TITLE
CMakeLists.txt: use find_library on non-windows platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,16 @@ add_subdirectory(src)
 add_executable(${PROJECT_NAME} ${SOURCE_CODE})
 
 #Raylib version used: 3.7.0
+IF (NOT WIN32)
+	find_library(RAYLIB raylib REQUIRED)
+ENDIF()
 
 IF (WIN32) #windows
     target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/libraylib.a opengl32 gdi32 winmm)
 ELSEIF (UNIX AND NOT APPLE) #linux
-    target_link_libraries(${PROJECT_NAME} PRIVATE raylib GL m pthread dl rt X11)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${RAYLIB} GL m pthread dl rt X11)
 ELSE() #mac, thanks TheGrand547!
-    target_link_libraries(${PROJECT_NAME} PRIVATE raylib "-framework OpenGL" "-framework IOKit" "-framework Cocoa")
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${RAYLIB} "-framework OpenGL" "-framework IOKit" "-framework Cocoa")
 ENDIF()
 
 #Compiler used: GCC 10.3.0


### PR DESCRIPTION
on many unix systems, packages installed not as part of the base system will not be in default linker paths, and cmake needs to go actually look for them either using pkg-config or cmake's own package configuration system.

using find_library solves this issue.

(tested on macOS arm64, with homebrew, which does this. does not build without this change if raylib is installed via homebrew)